### PR TITLE
부모 Component에서 자식 Component로 데이터 전달하기

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@
 // }
 
 import { Component } from './core/core.js'
+import FruitItem from './components/FruitItem'
 
 export default class App extends Component {
     constructor() {
@@ -25,12 +26,17 @@ export default class App extends Component {
         
         this.el.innerHTML = /* HTML */ `
             <h1>Fruits</h1>
-            <ul>
-                ${this.state.fruits
-                        .filter(fruit => fruit < 3000)
-                        .map(fruit => `<li>${fruit.name}</li>`)
-                        .join('')}
-            </ul>
-            `
+            <ul></ul>
+        `
+        const ulEl = this.el.querySelector('ul')
+        ulEl.append(...this.state.fruits
+                    .filter(fruit => fruit.price < 3000)
+                    .map(fruit => new FruitItem({
+                        props: {
+                            name: fruit.name,
+                            price: fruit.price
+                        }
+                    }).el)
+                ) //전개연산자의 활용
     }
 }

--- a/src/components/FruitItem.js
+++ b/src/components/FruitItem.js
@@ -1,0 +1,20 @@
+import { Component } from '../core/core'
+
+export default class FruitItem extends Component {
+    constructor(payload) {
+        super({
+            tagName: "li",
+            props: payload.props
+        })
+    }
+
+    render() {
+        this.el.innerHTML = /* html */`
+        <span>${this.props.name}</span>
+        <span>${this.props.price}</span>
+        `
+        this.el.addEventListener('click', () => {
+            console.log(this.props.name, this.props.price)
+        })
+    }
+}

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -8,10 +8,12 @@ export class Component {
     constructor(payload = {}) {
         const { 
             tagName  = 'div', 
-            state = {} 
+            state = {},
+            props = {} 
         } = payload
         this.el = document.createElement(tagName)
         this.state = state
+        this.props = props
         this.render()
     }
 


### PR DESCRIPTION
- render() 메서드에서 태그를 직접 생성하지 않고 Component를 활용하기
- component A가 내부에서 component B를 사용한다.
: component간의 부모-자식 관계 성립. (부모 A, 자식 B)
부모가 자식component에게 data를 내려줄 수 있다.

- append() 메서드 : 인자를 여러개 받을 수 있다.
: 배열의 요소를 append() 메서드 안에 각각 전달하고 싶으면
전개 연산자를 활용한다.
```
ulEl.append(...this.state.fruits
            .map(fruit => new FruitItem({
                props: {
                    name: fruit.name,
                    price: fruit.price
                }
            }).el)
        ) 
```